### PR TITLE
Make compatible with purescript 0.14.2

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -116,10 +116,8 @@ let additions =
   }
 -------------------------------
 -}
-
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200507/packages.dhall sha256:9c1e8951e721b79de1de551f31ecb5a339e82bbd43300eb5ccfb1bf8cf7bbd62
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210613/packages.dhall sha256:64d7b5a1921e8458589add8a1499a1c82168e726a87fc4f958b3f8760cca2efe
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -5,7 +5,7 @@ You can edit this file as you like.
 { name = "classnames"
 , license = "MIT"
 , repository = "https://github.com/dewey92/purescript-classnames"
-, dependencies = [ "record", "strings" ]
+, dependencies = [ "maybe", "prelude", "record", "strings", "tuples" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 }

--- a/src/ClassNames.purs
+++ b/src/ClassNames.purs
@@ -44,7 +44,7 @@ instance tupleClassNames :: (ClassNames l, ClassNames r) => ClassNames (l ^ r) w
 instance recordClassNames :: (RecordClassNames row rl, RL.RowToList row rl) => ClassNames (Record row) where
   classNames' row = recToClassNames row (RLProxy :: RLProxy rl)
 
-class RecordClassNames (row :: # Type) (rl :: RL.RowList) where
+class RecordClassNames (row :: Row Type) (rl :: RL.RowList Type) where
   recToClassNames :: Record row -> RLProxy rl -> Array String
 
 instance emptyRecordClassNames :: RecordClassNames row RL.Nil where


### PR DESCRIPTION
> The old unary # Type syntax for row kinds is deprecated and should instead be written as Row Type. The kind of RowList has changed from Type to Type -> Type

https://github.com/purescript/documentation/blob/master/migration-guides/0.14-Migration-Guide.md#polykinds--type--type