### PR TITLE
Update to v0.15.0

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -117,7 +117,7 @@ let additions =
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210613/packages.dhall sha256:64d7b5a1921e8458589add8a1499a1c82168e726a87fc4f958b3f8760cca2efe
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220510/packages.dhall sha256:0b0d4db1f2f0acd3b37fa53220644ac6f64cf9b5d0226fd097c0593df563d5be
 
 let overrides = {=}
 

--- a/src/ClassNames.purs
+++ b/src/ClassNames.purs
@@ -12,12 +12,12 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.String (joinWith)
-import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Tuple (Tuple(..))
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record (get)
-import Type.Data.RowList (RLProxy(..))
+import Type.Proxy (Proxy(..))
 
 infixr 6 type Tuple as ^
 infixr 6 Tuple as ^
@@ -42,10 +42,10 @@ instance tupleClassNames :: (ClassNames l, ClassNames r) => ClassNames (l ^ r) w
   classNames' (l ^ r) = classNames' l <> classNames' r
 
 instance recordClassNames :: (RecordClassNames row rl, RL.RowToList row rl) => ClassNames (Record row) where
-  classNames' row = recToClassNames row (RLProxy :: RLProxy rl)
+  classNames' row = recToClassNames row (Proxy :: Proxy rl)
 
 class RecordClassNames (row :: Row Type) (rl :: RL.RowList Type) where
-  recToClassNames :: Record row -> RLProxy rl -> Array String
+  recToClassNames :: Record row -> Proxy rl -> Array String
 
 instance emptyRecordClassNames :: RecordClassNames row RL.Nil where
   recToClassNames _ _ = []
@@ -57,7 +57,7 @@ instance boolRecordClassNames
   , Row.Cons label Boolean rowTail row
   ) => RecordClassNames row (RL.Cons label Boolean tail) where
   recToClassNames record _ = classname <> rest where
-    key = SProxy :: SProxy label
+    key = Proxy :: Proxy label
     value = get key record
     classname = if value then [reflectSymbol key] else []
-    rest = recToClassNames record (RLProxy :: RLProxy tail)
+    rest = recToClassNames record (Proxy :: Proxy tail)


### PR DESCRIPTION
Update to v0.15.0
- Use `Proxy` instead of all the deprecated types of Proxy